### PR TITLE
More meaning if it is true

### DIFF
--- a/src/robot/libraries/Telnet.py
+++ b/src/robot/libraries/Telnet.py
@@ -324,7 +324,7 @@ class Telnet(object):
         | Library     | Telnet    | 5 seconds                |                      |                     | # set only timeout |
         | Library     | Telnet    | newline=LF               | encoding=ISO-8859-1  |                     | # set newline and encoding using named arguments |
         | Library     | Telnet    | prompt=$                 |                      |                     | # set prompt |
-        | Library     | Telnet    | prompt=(> |# )           | prompt_is_regexp=yes |                     | # set prompt as a regular expression |
+        | Library     | Telnet    | prompt=(> |# )           | prompt_is_regexp=true|                     | # set prompt as a regular expression |
         | Library     | Telnet    | terminal_emulation=True  | terminal_type=vt100  | window_size=400x100 | # use terminal emulation with defined window size and terminal type |
         | Library     | Telnet    | telnetlib_log_level=NONE |                      |                     | # disable logging messages from the underlying telnetlib |
         """


### PR DESCRIPTION
yes is_string(item) will accept yes, Yes, True, true, It would be more meaning if we use `true` instead yes, Since through documentation we are using prompt_is_regexp=False, 

``` Python

def is_truthy(item):
    if is_string(item):
        return item.upper() not in ('FALSE', 'NO', '')
    return bool(item)
```
